### PR TITLE
PHP 8 migration

### DIFF
--- a/Utils/StringUtils.php
+++ b/Utils/StringUtils.php
@@ -217,7 +217,7 @@ class StringUtils
     {
         $encoded_text = '';
         for ($i = 0; $i < strlen($text); $i++) {
-            $char = $text{$i};
+            $char = $text[$i];
             $r    = rand(0, 100);
 
             # roughly 10% raw, 45% hex, 45% dec


### PR DESCRIPTION
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

## Goal
Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.